### PR TITLE
[Refactor/#1] PickerState to index-based generic state with reliable onValueChange

### DIFF
--- a/timepicker/src/main/java/com/dongchyeon/timepicker/TimePicker.kt
+++ b/timepicker/src/main/java/com/dongchyeon/timepicker/TimePicker.kt
@@ -35,7 +35,6 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import java.util.Locale
 
 @Composable
 fun TimePicker(
@@ -104,19 +103,19 @@ private fun TimePicker12Hour(
                             TimePeriod.PM.getLabel(localeTimeFormat)
                         )
                     }
-                    val hourItems = remember { (1..12).map { it.toString() } }
-                    val minuteItems = remember { (0..59).map { String.format(Locale.ROOT, "%02d", it) } }
+                    val hourItems = remember { (1..12).toList() }
+                    val minuteItems = remember { (0..59).toList() }
 
                     val amPmPickerState = rememberPickerState(
                         initialIndex = if (initialTime.hour < 12) 0 else 1,
                         items = amPmItems
                     )
                     val hourPickerState = rememberPickerState(
-                        initialIndex = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString()),
+                        initialIndex = hourItems.indexOf(if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12),
                         items = hourItems
                     )
                     val minutePickerState = rememberPickerState(
-                        initialIndex = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0')),
+                        initialIndex = minuteItems.indexOf(initialTime.minute),
                         items = minuteItems
                     )
 
@@ -196,7 +195,7 @@ private fun TimePicker12Hour(
                                     )
 
                                     scope.launch {
-                                        val currentHour = hourPickerState.selectedItem.toIntOrNull() ?: 0
+                                        val currentHour = hourPickerState.selectedItem
 
                                         if (currentHour == 12 && previousHour == 11) {
                                             val currentIndex = amPmPickerState.lazyListState.firstVisibleItemIndex % amPmItems.size
@@ -223,6 +222,9 @@ private fun TimePicker12Hour(
                                 modifier = Modifier.weight(1f),
                                 textModifier = Modifier.padding(8.dp),
                                 infiniteScroll = true,
+                                itemFormatter = { item ->
+                                    item.toString().padStart(2, '0')
+                                },
                                 onValueChange = {
                                     onPickerValueChange(
                                         amPmPickerState,
@@ -252,15 +254,15 @@ private fun TimePicker24Hour(
     selector: PickerSelector,
     onValueChange: (LocalTime) -> Unit
 ) {
-    val hourItems = remember { (1..23).map { it.toString() } }
-    val minuteItems = remember { (0..59).map { String.format(Locale.ROOT, "%02d", it) } }
+    val hourItems = remember { (1..23).toList() }
+    val minuteItems = remember { (0..59).toList() }
 
     val hourPickerState = rememberPickerState(
-        initialIndex = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString()),
+        initialIndex = hourItems.indexOf(if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12),
         items = hourItems
     )
     val minutePickerState = rememberPickerState(
-        initialIndex = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0')),
+        initialIndex = minuteItems.indexOf(initialTime.minute),
         items = minuteItems
     )
 
@@ -342,6 +344,9 @@ private fun TimePicker24Hour(
                                 modifier = Modifier.weight(1f),
                                 textModifier = Modifier.padding(8.dp),
                                 infiniteScroll = true,
+                                itemFormatter = { item ->
+                                    item.toString().padStart(2, '0')
+                                },
                                 onValueChange = {
                                     onPickerValueChange(
                                         hourPickerState,
@@ -359,15 +364,15 @@ private fun TimePicker24Hour(
 }
 
 private fun onPickerValueChange(
-    amPmState: PickerState,
-    hourState: PickerState,
-    minuteState: PickerState,
+    amPmState: PickerState<String>,
+    hourState: PickerState<Int>,
+    minuteState: PickerState<Int>,
     localeTimeFormat: LocaleTimeFormat,
     onValueChange: (LocalTime) -> Unit
 ) {
     val amPm = amPmState.selectedItem
-    val hour = hourState.selectedItem.toIntOrNull() ?: 0
-    val minute = minuteState.selectedItem.toIntOrNull() ?: 0
+    val hour = hourState.selectedItem
+    val minute = minuteState.selectedItem
 
     val adjustedHour = when (localeTimeFormat) {
         LocaleTimeFormat.ENGLISH -> {
@@ -396,12 +401,12 @@ private fun onPickerValueChange(
 }
 
 private fun onPickerValueChange(
-    hourState: PickerState,
-    minuteState: PickerState,
+    hourState: PickerState<Int>,
+    minuteState: PickerState<Int>,
     onValueChange: (LocalTime) -> Unit
 ) {
-    val hour = hourState.selectedItem.toIntOrNull() ?: 0
-    val minute = minuteState.selectedItem.toIntOrNull() ?: 0
+    val hour = hourState.selectedItem
+    val minute = minuteState.selectedItem
 
     val newTime = LocalTime(hour, minute)
 

--- a/timepicker/src/main/java/com/dongchyeon/timepicker/TimePicker.kt
+++ b/timepicker/src/main/java/com/dongchyeon/timepicker/TimePicker.kt
@@ -108,16 +108,16 @@ private fun TimePicker12Hour(
                     val minuteItems = remember { (0..59).map { String.format(Locale.ROOT, "%02d", it) } }
 
                     val amPmPickerState = rememberPickerState(
-                        selectedItem = amPmItems.indexOf(if (initialTime.hour < 12) amPmItems[0] else amPmItems[1]).toString(),
-                        startIndex = if (initialTime.hour < 12) 0 else 1
+                        initialIndex = if (initialTime.hour < 12) 0 else 1,
+                        items = amPmItems
                     )
                     val hourPickerState = rememberPickerState(
-                        selectedItem = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString()).toString(),
-                        startIndex = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString())
+                        initialIndex = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString()),
+                        items = hourItems
                     )
                     val minutePickerState = rememberPickerState(
-                        selectedItem = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0')).toString(),
-                        startIndex = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0'))
+                        initialIndex = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0')),
+                        items = minuteItems
                     )
 
                     var previousHour by remember { mutableIntStateOf(initialTime.hour) }
@@ -256,12 +256,12 @@ private fun TimePicker24Hour(
     val minuteItems = remember { (0..59).map { String.format(Locale.ROOT, "%02d", it) } }
 
     val hourPickerState = rememberPickerState(
-        selectedItem = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString()).toString(),
-        startIndex = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString())
+        initialIndex = hourItems.indexOf((if (initialTime.hour % 12 == 0) 12 else initialTime.hour % 12).toString()),
+        items = hourItems
     )
     val minutePickerState = rememberPickerState(
-        selectedItem = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0')).toString(),
-        startIndex = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0'))
+        initialIndex = minuteItems.indexOf(initialTime.minute.toString().padStart(2, '0')),
+        items = minuteItems
     )
 
     Box(modifier = modifier.fillMaxWidth()) {

--- a/timepicker/src/main/java/com/dongchyeon/timepicker/model/PickerState.kt
+++ b/timepicker/src/main/java/com/dongchyeon/timepicker/model/PickerState.kt
@@ -7,17 +7,17 @@ import androidx.compose.runtime.remember
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-class PickerState(
+class PickerState<T>(
     val lazyListState: LazyListState,
     initialIndex: Int,
-    private val items: List<String>
+    private val items: List<T>
 ) {
     private val _selectedIndex = MutableStateFlow(initialIndex)
     val selectedIndex: StateFlow<Int>
         get() = _selectedIndex
 
-    val selectedItem: String
-        get() = items.getOrElse(_selectedIndex.value) { "" }
+    val selectedItem: T
+        get() = items.getOrElse(_selectedIndex.value) { items.first() }
 
     fun updateSelectedIndex(newIndex: Int) {
         _selectedIndex.value = newIndex.coerceIn(0, items.size - 1)
@@ -25,8 +25,8 @@ class PickerState(
 }
 
 @Composable
-fun rememberPickerState(
+fun <T> rememberPickerState(
     lazyListState: LazyListState = rememberLazyListState(),
     initialIndex: Int = 0,
-    items: List<String> = emptyList()
-): PickerState = remember { PickerState(lazyListState, initialIndex, items) }
+    items: List<T>
+): PickerState<T> = remember { PickerState(lazyListState, initialIndex, items) }

--- a/timepicker/src/main/java/com/dongchyeon/timepicker/model/PickerState.kt
+++ b/timepicker/src/main/java/com/dongchyeon/timepicker/model/PickerState.kt
@@ -4,16 +4,29 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class PickerState(
     val lazyListState: LazyListState,
-    var selectedItem: String,
-    var startIndex: Int
-)
+    initialIndex: Int,
+    private val items: List<String>
+) {
+    private val _selectedIndex = MutableStateFlow(initialIndex)
+    val selectedIndex: StateFlow<Int>
+        get() = _selectedIndex
+
+    val selectedItem: String
+        get() = items.getOrElse(_selectedIndex.value) { "" }
+
+    fun updateSelectedIndex(newIndex: Int) {
+        _selectedIndex.value = newIndex.coerceIn(0, items.size - 1)
+    }
+}
 
 @Composable
 fun rememberPickerState(
     lazyListState: LazyListState = rememberLazyListState(),
-    selectedItem: String = "",
-    startIndex: Int = 0
-): PickerState = remember { PickerState(lazyListState, selectedItem, startIndex) }
+    initialIndex: Int = 0,
+    items: List<String> = emptyList()
+): PickerState = remember { PickerState(lazyListState, initialIndex, items) }

--- a/timepicker/src/main/java/com/dongchyeon/timepicker/ui/PickerItem.kt
+++ b/timepicker/src/main/java/com/dongchyeon/timepicker/ui/PickerItem.kt
@@ -57,8 +57,8 @@ internal fun PickerItem(
     var itemHeightPixels by remember { mutableIntStateOf(0) }
     val itemHeightDp = with(LocalDensity.current) { itemHeightPixels.toDp() }
 
-    LaunchedEffect(state.startIndex) {
-        val safeStartIndex = state.startIndex
+    LaunchedEffect(state.selectedIndex.value) {
+        val safeStartIndex = state.selectedIndex.value
         val listStartIndex = if (infiniteScroll) {
             getStartIndexForInfiniteScroll(itemHeightPixels, listScrollMiddle, visibleItemsMiddle, safeStartIndex)
         } else {
@@ -67,9 +67,9 @@ internal fun PickerItem(
         listState.scrollToItem(listStartIndex, 0)
 
         if (!infiniteScroll) {
-            val selectedItem = items.getOrNull(safeStartIndex) ?: ""
-            if (selectedItem != state.selectedItem) {
-                state.selectedItem = selectedItem
+            val selectedItem = items.getOrNull(listStartIndex) ?: ""
+            if (listStartIndex != state.selectedIndex.value) {
+                state.updateSelectedIndex(listStartIndex)
                 onValueChange(selectedItem)
             }
         }
@@ -94,11 +94,9 @@ internal fun PickerItem(
                         centerIndex - visibleItemsMiddle
                     }.coerceIn(0, items.size - 1)
 
-                    val newValue = items[adjustedIndex]
-
-                    if (newValue != state.selectedItem) {
-                        state.selectedItem = newValue
-                        onValueChange(newValue)
+                    if (adjustedIndex != state.selectedIndex.value) {
+                        state.updateSelectedIndex(adjustedIndex)
+                        onValueChange(items[adjustedIndex])
                     }
                 }
             }

--- a/timepicker/src/main/java/com/dongchyeon/timepicker/ui/PickerItem.kt
+++ b/timepicker/src/main/java/com/dongchyeon/timepicker/ui/PickerItem.kt
@@ -135,8 +135,15 @@ internal fun <T> PickerItem(
 
                 val scaleY = 1f - (0.2f * (distanceFromCenter / maxDistance)).coerceIn(0f, 0.4f)
 
+                val item = getItemForIndex(
+                    index = index,
+                    items = items,
+                    infiniteScroll = infiniteScroll,
+                    visibleItemsMiddle = visibleItemsMiddle
+                )
+
                 Text(
-                    text = itemFormatter(getItemForIndex(index, items, infiniteScroll, visibleItemsMiddle)),
+                    text = item?.let { itemFormatter(it) } ?: "",
                     maxLines = 1,
                     style = textStyle,
                     color = textColor.copy(alpha = alpha),
@@ -156,13 +163,13 @@ private fun <T> getItemForIndex(
     items: List<T>,
     infiniteScroll: Boolean,
     visibleItemsMiddle: Int
-): T {
+): T? {
     require(items.isNotEmpty()) { "Items list cannot be empty." }
 
     return if (!infiniteScroll) {
-        items.getOrNull(index - visibleItemsMiddle) ?: items.first()
+        items.getOrNull(index - visibleItemsMiddle)
     } else {
-        items.getOrNull(index % items.size) ?: items.first()
+        items.getOrNull(index % items.size)
     }
 }
 

--- a/timepicker/src/main/java/com/dongchyeon/timepicker/ui/PickerItem.kt
+++ b/timepicker/src/main/java/com/dongchyeon/timepicker/ui/PickerItem.kt
@@ -86,19 +86,20 @@ internal fun <T> PickerItem(
                     abs(itemCenter - centerOffset)
                 }?.index
             }
-            .distinctUntilChanged()
-            .collect { centerIndex ->
-                if (centerIndex != null) {
-                    val adjustedIndex = if (infiniteScroll) {
-                        centerIndex % items.size
+            .map { centerIndex ->
+                centerIndex?.let { index ->
+                    if (infiniteScroll) {
+                        index % items.size
                     } else {
-                        centerIndex - visibleItemsMiddle
-                    }.coerceIn(0, items.size - 1)
-
-                    if (adjustedIndex != state.selectedIndex.value) {
-                        state.updateSelectedIndex(adjustedIndex)
-                        onValueChange(items[adjustedIndex])
+                        (index - visibleItemsMiddle).coerceIn(0, items.size - 1)
                     }
+                }
+            }
+            .distinctUntilChanged()
+            .collect { adjustedIndex ->
+                if (adjustedIndex != null && adjustedIndex != state.selectedIndex.value) {
+                    state.updateSelectedIndex(adjustedIndex)
+                    onValueChange(items[adjustedIndex])
                 }
             }
     }


### PR DESCRIPTION
## 🎯 Related Issue

- Closes #1 

---

## 📝 Description

**What does this PR do?**

> Refactor `PickerState` to use index-based unidirectional state management for better consistency with Compose paradigms.  
> Make `PickerState` generic for type safety and reusability.  
> Refactor `PickerItem` scroll observer logic to calculate `adjustedIndex` before `distinctUntilChanged`, preventing skipped `onValueChange` triggers.  
> Ensure `getItemForIndex` returns an empty string when item is null to avoid displaying `"null"`.

---


## 🔄 Comparison

| Before | After |
| --- | --- |
| `PickerState` stored mutable `selectedItem` directly | Uses `selectedIndex: StateFlow<Int>` with derived `selectedItem` getter, enforcing unidirectional data flow |
| Only supported `String` items | Now supports generic types with type-safe selection |
| `distinctUntilChanged` applied to `centerIndex`, mapping afterwards | Calculates `adjustedIndex` before `distinctUntilChanged`, preventing skipped updates |
| `getItemForIndex` used `toString()` directly, risking `"null"` display | Returns empty string `""` safely when item is null |

---

## ✅ Changes

- [x] Refactor `PickerState` to index-based unidirectional state
- [x] Make `PickerState` generic for type safety
- [x] Calculate `adjustedIndex` before `distinctUntilChanged` in `PickerItem`
- [x] Return empty string when `item` is null in `getItemForIndex`

---

## 🔍 Screenshots / Test Results (if applicable)

_N/A_

---

## 👤 Reviewer Checklist

N/A